### PR TITLE
feat: Rewrite cache to use a map instead of array

### DIFF
--- a/chrome/bgrequests.js
+++ b/chrome/bgrequests.js
@@ -1,4 +1,4 @@
-const userDataCache = new Set();
+const userDataCache = new Map();
 const requestQueue = [];
 const openRequests = [];
 
@@ -51,7 +51,7 @@ async function returnData(id, port) {
     }
     
     requestQueue.splice(requestQueue.indexOf(id), 1);
-    userDataCache.add(id, userData);
+    userDataCache.set(id, userData);
 
     port.postMessage({ user: userData });
     userDataUpdated(id, userData);

--- a/chrome/bgrequests.js
+++ b/chrome/bgrequests.js
@@ -51,7 +51,9 @@ async function returnData(id, port) {
     }
     
     requestQueue.splice(requestQueue.indexOf(id), 1);
-    userDataCache.set(id, userData);
+
+    // Don't put more than 512 entries in this cache, PLEASE
+    userDataCache.size < 512 && userDataCache.set(id, userData);
 
     port.postMessage({ user: userData });
     userDataUpdated(id, userData);

--- a/chrome/bgrequests.js
+++ b/chrome/bgrequests.js
@@ -1,4 +1,4 @@
-const userDataCache = new Map();
+const userDataCache = new Set();
 const requestQueue = [];
 const openRequests = [];
 

--- a/chrome/bgrequests.js
+++ b/chrome/bgrequests.js
@@ -51,7 +51,7 @@ async function returnData(id, port) {
     }
     
     requestQueue.splice(requestQueue.indexOf(id), 1);
-    userDataCache.set(id, userData);
+    userDataCache.add(id, userData);
 
     port.postMessage({ user: userData });
     userDataUpdated(id, userData);


### PR DESCRIPTION
Pull request since this may or may not make the cut:

**Details**:
* Rewrite cache to use a map, and cache values into map on each call

**Possible Issues**:
Since this is done via a map in Chrome, there is no upperbound or limit to the amount of entries in this cache. Using a map in this way means that even refreshing the page, cache is still valid and takes up space in Chrome. I am not sure how this may impact people on lower end devices.

This would GREATLY reduce calls to APIs, and the cache would eventually clear, though I am not sure how this is stored in Chrome or when/how the cache would clear.

**Possible Solutions to Issues**:
* Add a button on popup to clear the cache

I'd like to know how you feel about this change, if you want this to be added to 1.0.0, or if you wish to keep it as is.